### PR TITLE
Affinities-based watershed

### DIFF
--- a/local_train.py
+++ b/local_train.py
@@ -22,8 +22,8 @@ labels_paths = [os.path.join(data_dir, '191113_IVMTR26_Inj3_cang_exp3_labels_58_
 # CHANGE THESE EACH TIME:
 # ---------------------------------------------------------------------------------------
 METHOD = 'get'
-out_dir = os.path.join(data_dir, '210324_training_0')
-suffix = 'z-1_z-2_y-1_y-2_y-3_x-1_x-2_x-3_c_cl'
+out_dir = os.path.join(data_dir, '210329_training_0')
+suffix = 'z-1_z-2_y-1_y-2_y-3_x-1_x-2_x-3_c_cl_cg'
 # ---------------------------------------------------------------------------------------
 
 
@@ -32,7 +32,7 @@ if METHOD == 'get':
     # CAN CHANGE THESE TOO
     # --------------------
     n_each = 100
-    channels = ('z-1', 'z-2','y-1', 'y-2', 'y-3', 'x-1', 'x-2', 'x-3', 'centreness', 'centreness-log')
+    channels = ('z-1', 'z-2','y-1', 'y-2', 'y-3', 'x-1', 'x-2', 'x-3', 'centreness', 'centreness-log', 'centroid-gauss')
     validation_prop = 0.2
     scale = (4, 1, 1)
     epochs = 4

--- a/segmentation.py
+++ b/segmentation.py
@@ -1,0 +1,105 @@
+from dask.array.core import Array
+from helpers import get_dataset
+import numpy as np
+from skimage.feature import peak_local_max, blob_dog, blob_log
+from skimage.filters import threshold_otsu
+from skimage import filters
+from watershed import watershed
+from time import time
+
+# --------------------
+# Segment U-net Output
+# --------------------
+
+def segment_output_image(unet_output, affinities_channels, centroids_channel, thresholding_channel):
+    '''
+    Parameters
+    ----------
+    unet_output: np.ndarray or dask.array.core.Array
+        Output from U-net inclusive of all channels. If there is an extra 
+        dim of size 1, this will be squeezed out. Therefore shape may be
+        (1, c, z, y, x) or (c, z, y, x).
+    affinities_channels: tuple of int
+        Ints, in order (z, y, x) describe the channel indicies to which 
+        the z, y, and x short-range affinities belong.
+    centroids_channel: int
+        Describes the channel index for the channel that is used to find 
+        centroids.
+    thresholding_channel: in
+        Describes the channel index for the channel that is used to find
+        the mask for watershed.
+    '''
+    t = time()
+    if isinstance(unet_output, Array):
+        unet_output = unet_output.compute()
+    unet_output = np.squeeze(unet_output)
+    # Get the affinities image (a, z, y, x)
+    affinties = []
+    for c in affinities_channels:
+        affinties.append(unet_output[c, ...]/unet_output[c, ...].max())
+    affinties = np.stack(affinties)
+    affinties = np.pad(affinties, 1, constant_values=0)
+    # Get the image for finding centroids
+    centroids_img = unet_output[centroids_channel]
+    centroids_img = np.pad(centroids_img, 1, constant_values=0)
+    # find the centroids
+    centroids = _get_centroids(centroids_img)
+    # Get the image for finding the mask 
+    masking_img = unet_output[thresholding_channel]
+    # find the mask for use with watershed
+    mask = _get_mask(masking_img)
+    mask = np.pad(mask, 1, constant_values=0) # edge voxels must be 0
+    # affinity-based watershed
+    segmentation = watershed(affinties, centroids, mask, affinities=True)
+    segmentation = segmentation[1:-1, 1:-1, 1:-1]
+    seeds = centroids - 1
+    print(f'Obtained segmentation in {time() - t} seconds')
+    return segmentation, seeds
+
+
+def _get_mask(img, sigma=2):
+    thresh = threshold_otsu(filters.gaussian(img, sigma=sigma))
+    mask = img > thresh
+    return mask
+
+
+def _get_centroids(cent, gaussian=True):
+    if gaussian:
+        # won't blur along z, can't afford to do that
+        for i in range(cent.shape[0]):
+            cent[i, ...] = filters.gaussian(cent[i, ...])
+    centroids = peak_local_max(cent, threshold_abs=.04) #* c_scale
+    #centroids = blob_log(cent, min_sigma=min_sigma, max_sigma=max_sigma, threshold=threshold)
+    return centroids
+
+
+if __name__ == '__main__':
+    import os
+    data_dir = '/Users/amcg0011/Data/pia-tracking/cang_training'
+    train_dir = os.path.join(data_dir, '210324_training_0')
+    channels = ('z-1', 'z-2','y-1', 'y-2', 'y-3', 'x-1', 'x-2', 'x-3', 'centreness', 'centreness-log')
+    images, labs, output = get_dataset(train_dir)
+    o88 = output[88]
+    aff_chans = (0, 2, 5)
+    cent_chan = 9
+    mask_chan = 8
+    seg88, s88 = segment_output_image(o88, aff_chans, cent_chan, mask_chan)
+    i88 = images[88]
+    l88 = labs[88]
+    import napari 
+    v = napari.view_image(i88, name='image', scale=(4, 1, 1), blending='additive')
+    #v.add_labels(l88, name='labels', scale=(4, 1, 1), visible=False)
+    v.add_image(o88[aff_chans[0]], name='z affinities', 
+                colormap='bop purple', scale=(4, 1, 1), 
+                visible=False, blending='additive')
+    v.add_image(o88[aff_chans[1]], name='y affinities', 
+                colormap='bop orange', scale=(4, 1, 1), 
+                visible=False, blending='additive')
+    v.add_image(o88[aff_chans[2]], name='x affinities', 
+                colormap='bop blue', scale=(4, 1, 1), 
+                visible=False, blending='additive')
+    v.add_labels(seg88, name='affinity watershed', 
+                 scale=(4, 1, 1), blending='additive')
+    v.add_points(s88, name='seeds', scale=(4, 1, 1), size=1)
+    napari.run()
+

--- a/train.py
+++ b/train.py
@@ -41,7 +41,8 @@ def train_unet(
                loss_function='WeightedBCE', 
                chan_weights=(1., 2., 2.), # for weighted BCE
                weights=None,
-               update_every=20
+               update_every=20, 
+               **kwargs
                ):
     '''
     Train a basic U-Net on affinities data.
@@ -364,7 +365,8 @@ def train_unet_from_directory(
                               chan_weights=(1., 2., 2.), # for weighted BCE
                               weights=None,
                               update_every=20, 
-                              channels=None
+                              channels=None, 
+                              **kwargs
                               ):
     '''
     Train a basic U-Net on affinities data. Load chunks of training data
@@ -493,7 +495,8 @@ def train_unet_get_labels(
                           loss_function='BCELoss', 
                           chan_weights=(1., 2., 2.), # for weighted BCE
                           weights=None,
-                          update_every=20
+                          update_every=20,
+                          **kwargs
                           ):
     '''
     Train a basic U-Net on affinities data. Generates chunks of training data

--- a/watershed.py
+++ b/watershed.py
@@ -1,0 +1,353 @@
+import numpy as np
+import napari
+import os
+from skimage.io import imread
+from skimage.measure import regionprops
+from skimage.morphology._util import _offsets_to_raveled_neighbors, _validate_connectivity
+
+selem = np.array(
+    [[[0., 0., 0.],
+      [0., 1., 0.],
+      [0., 0., 0.]],
+
+     [[0., 1., 0.],
+      [1., 1., 1.],
+      [0., 1., 0.]],
+
+     [[0., 0., 0.],
+      [0., 1., 0.],
+      [0., 0., 0.]]])
+
+selem1 = np.array(
+    [[1., 1., 1.], 
+    [1., 1., 1.], 
+    [1., 1., 1.]])
+
+
+# --------------
+# Mock Watershed
+# --------------
+
+def mock_watershed(image, marker_coords, mask, 
+                   compactness, affinities=False):
+    prepped_data = prep_data(image, marker_coords, mask, affinities)
+    image_raveled, marker_coords, offsets, mask, output, strides = prepped_data
+    output = slow_raveled_watershed(image_raveled, marker_coords, 
+                                    offsets, mask, strides, compactness, 
+                                    output, affinities)
+    if affinities:
+        shape = image.shape[1:]
+    else:
+        shape = image.shape
+    output = output.reshape(shape)
+    return output
+
+
+def prep_data(image, marker_coords, mask=None, affinities=False, output=None):
+    # INTENSITY VALUES
+    if affinities:
+        im_ndim = image.ndim - 1 # the first dim should represent affinities
+        image_shape = image.shape[1:]
+        image_strides = image[0].strides
+        image_itemsize = image[0].itemsize
+        raveled_image = np.zeros((image.shape[0], image[0].size), dtype=image.dtype)
+        for i in range(image.shape[0]):
+            raveled_image[i] = image[i].ravel()
+    else:
+        im_ndim = image.ndim
+        image_shape = image.shape
+        image_strides = image.strides
+        image_itemsize = image.itemsize
+        raveled_image = image.ravel()
+    # NEIGHBORS
+    selem, centre = _validate_connectivity(im_ndim, 1, None)
+    if affinities:
+        # array of shape (ndim * 2, 2) giving the indicies of neighbor affinities
+        offsets = _indices_to_raveled_affinities(image_shape, selem, centre)
+    else:
+        offsets = _offsets_to_raveled_neighbors(image_shape, selem, centre)
+    raveled_markers = np.apply_along_axis(raveled_coordinate, 1, 
+                                          marker_coords, **{'shape':image_shape})
+    if mask is None:
+        small_shape = [s - 2 for s in image_shape]
+        mask = np.ones(small_shape, dtype=bool)
+        mask = np.pad(mask, 1, constant_values=0)
+        assert image_shape == mask.shape
+    mask_raveled = mask.ravel()
+    if output is None:
+        output = np.zeros(mask_raveled.shape, dtype=raveled_image.dtype)
+        labels = np.arange(len(raveled_markers)) + 1
+        output[raveled_markers] = labels
+    strides = np.array(image_strides, dtype=np.intp) // image_itemsize
+    return raveled_image, raveled_markers, offsets, mask_raveled, output, strides
+
+
+def raveled_coordinate(coordinate, shape):
+    # array[z, y, x] = array.ravel()[z * array.shape[1] * array.shape[2] + y * array.shape[2] + x]
+    raveled_coord = 0
+    for i in range(len(coordinate)):
+        to_add = coordinate[i]
+        for j in range(len(shape)):
+            if j > i:
+                to_add *= shape[j]
+        raveled_coord += to_add
+    return raveled_coord
+    
+
+def _indices_to_raveled_affinities(image_shape, selem, centre):
+    im_offsets = _offsets_to_raveled_neighbors(image.shape, selem, centre)
+    affs = np.concatenate([np.arange(len(image_shape)), 
+                           np.arange(len(image_shape))[::-1]])
+    indices = np.stack([affs, im_offsets], axis=1)
+    return indices
+
+
+
+def slow_raveled_watershed(image_raveled, marker_coords, offsets, mask, 
+                           strides, compactness, output, affinities):
+    heap = Heap()
+    n_neighbors = offsets.shape[0]
+    age = 1
+    compact = compactness > 0
+    # add each seed to the stack
+    for i in range(marker_coords.shape[0]):
+        elem = Element()
+        index = marker_coords[i]
+        if affinities:
+            elem.value = 0.
+        else:
+            elem.value = image_raveled[index]
+        elem.source = index
+        elem.index = index
+        elem.age = 0
+        heap.push(elem)
+    # remove from stack until empty
+    while not heap.is_empty:
+        elem = heap.pop()
+        if compact:
+            if output[elem.index] and elem.index != elem.source:
+                # non-marker, already visited, move on to next item
+                continue
+            output[elem.index] = output[elem.source]
+        for i in range(n_neighbors):
+            # get the flattened address of the neighbor
+            if affinities:
+                # offsets are 2d (size, 2) with columns 0 and 1 corresponding to 
+                # affinities and image neighbour indices respectively
+                neighbor_index = offsets[i, 1] + elem.index
+                # in this case the index used to find elem.value will be 2d tuple
+                affinity_index = tuple(offsets[i] + np.array([0, elem.index]))
+            else:
+                neighbor_index = offsets[i] + elem.index
+            if not mask[neighbor_index]:
+                # neighbor is not in mask, move on to next neighbor
+                continue
+            if output[neighbor_index]:
+                # if there is a non-zero value in output, move on to next neighbor
+                continue
+            # if the neighbor is in the mask and not already labeled, add to queue
+            age += 1
+            new_elem = Element()
+            if affinities:
+                new_elem.value = image_raveled[affinity_index]
+            else:
+                new_elem.value = image_raveled[neighbor_index]
+            if compact:
+                new_elem.value += (compactness *
+                                       _euclid_dist(neighbor_index, elem.source,
+                                                        strides))
+            output[neighbor_index] = output[elem.index]
+            new_elem.age = age
+            new_elem.index = neighbor_index
+            new_elem.source = elem.source
+            heap.push(new_elem)
+    return output
+
+
+def _euclid_dist(pt0, pt1, strides):
+    result, curr = 0, 0
+    for i in range(strides.shape[0]):
+        curr = (pt0 // strides[i]) - (pt1 // strides[i])
+        result += curr * curr
+        pt0 = pt0 % strides[i]
+        pt1 = pt1 % strides[i]
+    return np.sqrt(result)
+    
+
+class Element:
+    def __init__(self, value=None, index=None, age=None, source=None):
+        self._value = value
+        self._index = index
+        self._age = age
+        self._source = source
+    @property
+    def value(self):
+        return self._value
+    @value.setter
+    def value(self, v):
+        self._value = v
+    @property
+    def index(self):
+        return self._index
+    @index.setter
+    def index(self, i):
+        self._index = i
+    @property
+    def age(self):
+        return self._age
+    @age.setter
+    def age(self, a):
+        self._age = a
+    @property
+    def source(self):
+        return self._source
+    @source.setter
+    def source(self, s):
+        self._source = s
+
+
+class Heap:
+    def __init__(self):
+        self.items = {}
+        self.values = []
+        self.ids = []
+        self.id = 0
+
+    @property
+    def is_empty(self):
+        return len(self.ids) == 0
+
+    def push(self, item: Element):
+        '''
+        Add an element to the heap
+
+        Parameters
+        ----------
+        item: Element
+        '''
+        # add the item to the new ID
+        self.items[self.id] = item
+        self.ids.append(self.id)
+        self.values.append(item.value)
+        # get the ID current order and the current values
+        old_id_order = np.array(self.ids)
+        old_value_list = np.array(self.values)
+        # sort the ID order according to values (lowest @ -1)
+        new_indicies = np.argsort(old_value_list)[::-1]
+        self.ids = old_id_order[new_indicies].tolist()
+        self.values = old_value_list[new_indicies].tolist()
+        # new ID
+        self.id += 1
+
+    def pop(self):
+        '''
+        Remove the highest value element from the heap
+        '''
+        elem = self.items.pop(self.ids[-1])
+        self.ids = self.ids[:-1]
+        self.values = self.values[:-1]
+        return elem
+
+    def peek(self):
+        return self.items[self.ids[-1]]
+
+    def size(self):
+        return len(self.items)
+
+
+# not used
+def get_centroids(labels):
+    centroids = [prop['centroid'] for prop in regionprops(labels)]
+    centroids = np.round(np.stack(centroids).T).astype(int)
+    return centroids
+
+
+if __name__ == '__main__':
+    #import skimage.io as io
+    #labs = io.imread('/Users/amcg0011/Data/pia-tracking/cang_training/191113_IVMTR26_I3_E3_t58_cang_training_labels.tif')
+    #img = io.imread('/Users/amcg0011/Data/pia-tracking/cang_training/191113_IVMTR26_I3_E3_t58_cang_training_image.tif')
+    from scipy import ndimage as ndi
+    from skimage.feature import peak_local_max
+
+
+    # Generate an initial image with two overlapping circles
+    x, y = np.indices((80, 80))
+    x1, y1, x2, y2 = 28, 28, 44, 52
+    r1, r2 = 16, 20
+    mask_circle1 = (x - x1)**2 + (y - y1)**2 < r1**2
+    mask_circle2 = (x - x2)**2 + (y - y2)**2 < r2**2
+    image = np.logical_or(mask_circle1, mask_circle2)
+    # Now we want to separate the two objects in image
+    # Generate the markers as local maxima of the distance to the background
+    distance = ndi.distance_transform_edt(image)
+    coords = peak_local_max(distance, footprint=np.ones((3, 3)), labels=image)
+    distance = 1 - (distance / distance.max())
+    out = mock_watershed(distance, coords, image, 0)
+    from train_io import get_affinities
+    affs = get_affinities(out.copy())
+    from skimage.filters import gaussian
+    a_out = mock_watershed(affs.copy(), coords, image, 0, affinities=True)
+    affs_g = np.stack([gaussian(affs[i], sigma=1) for i in range(affs.shape[0])])
+    ag_out = mock_watershed(affs_g.copy(), coords, image, 0, affinities=True)
+    import napari
+    v = napari.view_labels(image, name='mask', blending='additive', visible=False)
+    v.add_labels(out, name='watershed', blending='additive', visible=False)
+    v.add_image(affs[0], name='y affinities', blending='additive', colormap='green', visible=False)
+    v.add_image(affs[1], name='x affinities', blending='additive', colormap='magenta', visible=False)
+    v.add_labels(a_out, name='affinity watershed', blending='additive', visible=False)
+    v.add_image(affs_g[0], name='y affinities (Gaussian)', blending='additive', colormap='green', visible=False)
+    v.add_image(affs_g[1], name='x affinities (Gaussian)', blending='additive', colormap='magenta', visible=False)
+    v.add_labels(ag_out, name='affinity watershed (Gaussian)', blending='additive')
+    v.add_points(coords, size=2)
+    napari.run()
+
+
+    #from helpers import get_files, get_paths
+
+    #data_dir = '/Users/amcg0011/Data/pia-tracking/cang_training'
+    #train_dir = os.path.join(data_dir, 'cang_training_data')
+    #prediction_dir = os.path.join(data_dir, '210314_training_0')
+
+    # Get the file paths
+    #image_files, affinities_files = get_files(train_dir)
+    #prediction_files = get_paths(prediction_dir)
+
+    # Get some sample images
+    #i0 = imread(image_files[0])
+    #a0 = imread(affinities_files[0])
+    #p0 = imread(prediction_files[0])
+
+
+# ----------------
+# This Didn't Work
+# ----------------
+
+#from elf.segmentation.workflows import simple_multicut_workflow
+#from elf.segmentation.mutex_watershed import mutex_watershed
+#from helpers import get_files, get_paths
+# GOT SOME INTERESTING TRACEBACKS!!
+#seg_a0 = simple_multicut_workflow(a0, True, 'blockwise-multicut') 
+#seg_p0 = simple_multicut_workflow(p0, False, 'greedy-additive') 
+
+
+# ----------------------------
+# Playing With Raveled Indices
+# ----------------------------
+
+#OFFSETS = [[-1, 0, 0], [0, -1, 0], [0, 0, -1]]
+#STRIDES = [1, 1, 1]
+# CAN'T GET AFFORGATO
+#mw_a0 = mutex_watershed(a0, OFFSETS, STRIDES)
+#offsets = _offsets_to_raveled_neighbors((10, 256, 256), selem, (1, 1, 1))
+#image = np.random.random((100, 100))
+#offsets = _offsets_to_raveled_neighbors((100, 100), np.ones((3, 3)), (1, 1))
+#image_raveled = image.raveled()
+#pixel_pos = [49, 49]
+#selem = np.ones((3, 3))
+#selem_indices = np.stack(np.nonzero(selem), axis=-1)
+#offsets = selem_indices - (1,1)
+#ravel_factors = image.shape[1:] + (1,)
+#raveled_offsets = (offsets * ravel_factors).sum(axis=1)    
+# similarly
+#i = np.array([[12, 23, 31], [43, 39, 24]])
+#ir = np.ravel_multi_index(i, (100, 100))


### PR DESCRIPTION
Added a pure python implementation of a watershed which works with edge affinities when `affinities` parameter is set as `True`, which it is by default. Affinities image must have affinity channels in axis 0 (e.g., (3, z, y, x)). Additionally, code for segmenting from u-net output can be found in segmentation.py.

```python
labels = watershed(affinities, seeds, mask, affinities=True)
```

## To Do
- anisotropic watershed?
- fix spelling errors
- refine segmentation
- port to cython
- docstrings 😝 